### PR TITLE
Drop `async-trait` dependency and use the new `AFIT` RFC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -596,7 +596,6 @@ name = "lure"
 version = "0.2.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "clap",
  "confique",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
-async-trait = "0.1.74"
 clap = { version = "4.4.8", features = ["derive"] }
 confique = { git = "https://github.com/tuhanayim/confique", rev = "2c85724", default-features = false, features = [
   "toml",

--- a/src/platforms/lastfm.rs
+++ b/src/platforms/lastfm.rs
@@ -17,7 +17,6 @@ pub struct LastFM {
     pub api_key: String,
 }
 
-#[async_trait::async_trait]
 pub trait LastFMPlatform: Platform {
     const USER_AGENT: &'static str = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/116.0.0.0 Safari/537.36";
     const API_URL: &'static str;
@@ -25,7 +24,6 @@ pub trait LastFMPlatform: Platform {
     async fn event_loop(self, tx: UnboundedSender<ChannelPayload>, check_interval: u64);
 }
 
-#[async_trait::async_trait]
 impl LastFMPlatform for LastFM {
     const API_URL: &'static str = "https://ws.audioscrobbler.com/2.0";
 
@@ -48,7 +46,6 @@ impl LastFMPlatform for LastFM {
     }
 }
 
-#[async_trait::async_trait]
 impl Platform for LastFM {
     type Platform = Self;
 

--- a/src/platforms/listenbrainz.rs
+++ b/src/platforms/listenbrainz.rs
@@ -38,7 +38,6 @@ impl ListenBrainz {
     }
 }
 
-#[async_trait::async_trait]
 impl Platform for ListenBrainz {
     type Platform = Self;
 

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -13,7 +13,6 @@ pub struct Status {
     pub idle: Option<String>,
 }
 
-#[async_trait::async_trait]
 pub trait Platform {
     type Platform;
 

--- a/src/rive.rs
+++ b/src/rive.rs
@@ -4,13 +4,11 @@ use rive_models::{
     user::{FieldsUser, UserStatus},
 };
 
-#[async_trait::async_trait]
 pub trait ClientExt {
     async fn ping(&self) -> Option<()>;
-    async fn set_status(&self, status: Option<String>) -> ();
+    async fn set_status(&self, status: Option<String>);
 }
 
-#[async_trait::async_trait]
 impl ClientExt for Client {
     async fn ping(&self) -> Option<()> {
         tracing::debug!("pinging Revolt API");


### PR DESCRIPTION
https://rust-lang.github.io/rfcs/3185-static-async-fn-in-trait.html